### PR TITLE
Add migration for checkmark field to five_a_day

### DIFF
--- a/db/migrate/201509171317_add_completed_to_five_a_day.rb
+++ b/db/migrate/201509171317_add_completed_to_five_a_day.rb
@@ -1,0 +1,5 @@
+class AddCompletedToFiveADay < ActiveRecord::Migration
+  def change
+  	add_column :five_a_day_counts, :completed, :boolean, :default => false
+  end
+end


### PR DESCRIPTION
Keep track of how many times a user has submitted 5 qualifying comments in a day, for future implementation of a Github-like streak tracker.
